### PR TITLE
Bump RuboCop dependency versions and update configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,10 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.7
 
+# Put development dependencies in the gemspec so rubygems.org knows about them
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92

--- a/tracy.gemspec
+++ b/tracy.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "aruba", "~> 2.0"
   s.add_development_dependency "cucumber", "~> 8.0"
   s.add_development_dependency "rake", "~> 13.0"
-  s.add_development_dependency "rubocop", "~> 1.25"
-  s.add_development_dependency "rubocop-performance", "~> 1.13"
+  s.add_development_dependency "rubocop", "~> 1.52"
+  s.add_development_dependency "rubocop-performance", "~> 1.18"
 end


### PR DESCRIPTION
- Bump versions for rubocop dependencies
- Require development dependencies to be in the gemspec
